### PR TITLE
feat: bump sonar-scanner-cli to 5.0.1.3006

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This action downloads given version of sonar-scanner and adds it to PATH.
 
 ### `version`
 
-**Required** sonar-scanner cli version. List of available versions: https://github.com/SonarSource/sonar-scanner-cli/releases. Default `5.0.0.2966`.
+**Optional** sonar-scanner cli version. List of available versions: https://github.com/SonarSource/sonar-scanner-cli/releases. Default `5.0.1.3006`.
 
 ## Full Example usage
 

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: 'Sonar-scanner version'
     required: true
     # https://github.com/SonarSource/sonar-scanner-cli/releases
-    default: '5.0.0.2966'
+    default: '5.0.1.3006'
 branding:
   icon: 'check'
   color: 'gray-dark'


### PR DESCRIPTION
Bump to this version as default, which fixes the issue that sonar scanner is not able to execute external programs.

Release: https://github.com/SonarSource/sonar-scanner-cli/releases/tag/5.0.1.3006
Changelog: https://github.com/SonarSource/sonar-scanner-cli/compare/5.0.0.2966...5.0.1.3006