### PR TITLE
remove default value for inputs.arch - breaks auto-detection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,6 @@ inputs:
     description: 'Sonar-scanner arch'
     required: false
     # https://github.com/SonarSource/sonar-scanner-cli/releases
-    default: 'x64'
 branding:
   icon: 'check'
   color: 'gray-dark'


### PR DESCRIPTION
remove default value for inputs.arch because it breaks the auto-detection fallback to getArch()

Before:

If no input value for arch is is supplied it auto-fallback to 'x64' which shunts getArch() method entirely.

```js
   const arch = core.getInput('arch', { required: false }) || getArch();
```

After:

If no value is supplied for arch it falls back to getArch() 

```js
const getArch = () => {
  switch(process.arch) {
    case 'x64':
      return 'x64'
    case 'arm64':
      return 'aarch64'
    default:
      throw new Error(`Unsupported architecture: ${process.arch}`);
  }
}
```